### PR TITLE
libretro: intentionally overwrite keymaps from ROMs, as many are still blank

### DIFF
--- a/source/core/romSetup.cpp
+++ b/source/core/romSetup.cpp
@@ -238,13 +238,6 @@ PD777::setupCode(const void* data, size_t dataSize)
     }
    
     for(auto& r : rom) { r = ~0; }
-    keyMapping.bitMap[0] = 0x40;            // B09 => K7
-    keyMapping.bitMap[1] = 0x20;            // B10 => K6
-    keyMapping.bitMap[2] = 0x10;            // B11 => K5
-    keyMapping.bitMap[3] = 0x08;            // B12 => K4
-    keyMapping.bitMap[4] = 0x04;            // B13 => K3
-    keyMapping.bitMap[5] = 0x02;            // B14 => K2
-    keyMapping.bitMap[6] = 0x01;            // B15 => K1
 
     if(isCodeRawOrder(data, dataSize)) {
         // 順番に並んだコード
@@ -259,6 +252,17 @@ PD777::setupCode(const void* data, size_t dataSize)
         // 未対応
         return false;
     }
+
+    // Set default wiring, only some games will adjust this.
+    // TODO (mittonk): Intentionally squashing anything loaded from bin777 v2
+    // files, this will need to be adjusted once those fields are populated...
+    keyMapping.bitMap[0] = 0x40;            // B09 => K7
+    keyMapping.bitMap[1] = 0x20;            // B10 => K6
+    keyMapping.bitMap[2] = 0x10;            // B11 => K5
+    keyMapping.bitMap[3] = 0x08;            // B12 => K4
+    keyMapping.bitMap[4] = 0x04;            // B13 => K3
+    keyMapping.bitMap[5] = 0x02;            // B14 => K2
+    keyMapping.bitMap[6] = 0x01;            // B15 => K1
 
     // 適当計算
     // @todo かっこいいのに変更すること！

--- a/source/libretro/cat/catAudio.cpp
+++ b/source/libretro/cat/catAudio.cpp
@@ -39,7 +39,7 @@ void CatAudio::addScore(u8 channel, u8 value, bool reverberatedSoundEffect) {
 
 void CatAudio::present() {
     // const len = outputs[0][0].length;
-    float masterVolume = 0.5; // 0.3;
+    float masterVolume = 10.0; // 0.3;  // TODO (mittonk): Adjustable?
     float v = 0.0;
     float value = 0.0;
     const u16 len = samplesPerSec / 60;

--- a/source/libretro/libretro.cpp
+++ b/source/libretro/libretro.cpp
@@ -442,10 +442,10 @@ bool retro_load_game(const struct retro_game_info *info)
     }
 
     // Try to load a similarly-named pattern file.
-    std::string pattern_path = info->path;
-    std::string toReplace = "bin777";
-    std::string replaceWith = "ptn777";
-    std::size_t pos = pattern_path.find(toReplace);
+    std::string pattern_path(info->path);
+    const std::string toReplace = "bin777";
+    const std::string replaceWith = "ptn777";
+    const std::size_t pos = pattern_path.rfind(toReplace);
     if (pos != std::string::npos) { // Check if the substring was found
         pattern_path.replace(pos, toReplace.length(), replaceWith);
     }


### PR DESCRIPTION
Rely on the keymaps stored in C++, rather than the ROMs, for now.

Would be better to just update the conversion routines over in PD777supplement, though.