### PR TITLE
ci: add a Linux aarch64 build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,6 +31,10 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-i686.yml'
 
+  # Linux ARM 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-aarch64.yml'
+
   # MacOS 64-bit
   - project: 'libretro-infrastructure/ci-templates'
     file: '/osx-x64.yml'
@@ -135,6 +139,12 @@ libretro-build-linux-x64:
 libretro-build-linux-i686:
   extends:
     - .libretro-linux-i686-make-default
+    - .core-defs
+
+# Linux ARM 64-bit
+libretro-build-linux-aarch64:
+  extends:
+    - .libretro-linux-aarch64-make-default
     - .core-defs
 
 # MacOS 64-bit


### PR DESCRIPTION
The libretro buildbot ships no aarch64 Linux build of this core, so it can't be installed from RetroArch's Core Downloader on ARM64 Linux machines (ARM Chromebooks, SBCs, ARM laptops). Nothing blocks it: the `unix` branch of `Makefile.libretro` is architecture-neutral, every ARM-specific branch in that file is a 32-bit one (`classic_armv7_a7`, `rpi*`, `armv6j` …), and `android-arm64-v8a` plus `osx-arm64` already build these sources for ARM64.

This adds the `/linux-aarch64.yml` template and one job mirroring the x64 one:

```yaml
libretro-build-linux-aarch64:
  extends:
    - .libretro-linux-aarch64-make-default
    - .core-defs
```

`.core-defs` stays last in `extends`, as in the existing Linux jobs, so `MAKEFILE`/`MAKEFILE_PATH`/`CORENAME` keep their values.

Verified on aarch64 (postmarketOS, glibc, GCC 15): `make -f Makefile.libretro platform=unix` builds clean with no source changes, and the resulting `pd777_libretro.so` (ELF 64-bit ARM aarch64) runs in RetroArch 1.22.2 — the built-in balloon demo renders correctly at 375x240, 60.1 fps (I have no Cassette Vision dumps, so I relied on the `rom.cpp` fallback documented in the README). Driven through a minimal libretro host on the same machine it runs 120 frames in 1.24 s, ~160% of realtime.
